### PR TITLE
Generate the PDF properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Depends on wkhtmltopdf library
+http://wkhtmltopdf.org/downloads.html
+

--- a/test.go
+++ b/test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"wkhtmltopdf"
+	"github.com/hailocab/wkhtmltopdf-go/wkhtmltopdf"
 )
 
 func main() {

--- a/test.go
+++ b/test.go
@@ -26,6 +26,7 @@ func main() {
 
 	c := gs.NewConverter()
 	c.Add(os)
+	//c.AddHtml(os, "<html><body><h3>HELLO</h3><p>World</p></body></html>")
 
 	c.ProgressChanged = func(c *wkhtmltopdf.Converter, b int) {
 		fmt.Printf("Progress: %d\n", b)

--- a/test.go
+++ b/test.go
@@ -14,7 +14,7 @@ func main() {
 	gs.Set("colorMode", "Color")
 	gs.Set("size.paperSize", "A4")
 	//gs.Set("load.cookieJar", "myjar.jar")
-	// object settings: http://www.cs.au.dk/~jakobt/libwkhtmltox_0.10.0_doc/pagesettings.html#pagePdfGlobal
+	// object settings: http://www.cs.au.dk/~jakobt/libwkhtmltox_0.10.0_doc/pagesettings.html#pagePdfObject
 	os := wkhtmltopdf.NewObjectSettings()
 	os.Set("page", "http://www.slashdot.org")
 	os.Set("load.debugJavascript", "false")

--- a/test.go
+++ b/test.go
@@ -6,12 +6,23 @@ import (
 )
 
 func main() {
+	// global settings: http://www.cs.au.dk/~jakobt/libwkhtmltox_0.10.0_doc/pagesettings.html#pagePdfGlobal
 	gs := wkhtmltopdf.NewGolbalSettings()
+	gs.Set("outputFormat", "pdf")
 	gs.Set("out", "test.pdf")
-	gs.Set("load.cookieJar", "myjar.jar")
+	gs.Set("orientation", "Portrait")
+	gs.Set("colorMode", "Color")
+	gs.Set("size.paperSize", "A4")
+	//gs.Set("load.cookieJar", "myjar.jar")
+	// object settings: http://www.cs.au.dk/~jakobt/libwkhtmltox_0.10.0_doc/pagesettings.html#pagePdfGlobal
 	os := wkhtmltopdf.NewObjectSettings()
-	//os.Set("page", "file:///home/jimmy/libwk/invoice.html")
-	os.Set("page", "http://www.google.se")
+	os.Set("page", "http://www.slashdot.org")
+	os.Set("load.debugJavascript", "false")
+	//os.Set("load.jsdelay", "1000") // wait max 1s
+	os.Set("web.enableJavascript", "false")
+	os.Set("web.enablePlugins", "false")
+	os.Set("web.loadImages", "true")
+	os.Set("web.background", "true")
 
 	c := gs.NewConverter()
 	c.Add(os)

--- a/test.go
+++ b/test.go
@@ -14,6 +14,7 @@ func main() {
 	os.Set("page", "http://www.google.se")
 
 	c := gs.NewConverter()
+	c.Add(os)
 
 	c.ProgressChanged = func(c *wkhtmltopdf.Converter, b int) {
 		fmt.Printf("Progress: %d\n", b)

--- a/wkhtmltopdf/pdf_c_api.go
+++ b/wkhtmltopdf/pdf_c_api.go
@@ -127,6 +127,12 @@ func (self *Converter) Add(settings *ObjectSettings) {
 	C.wkhtmltopdf_add_object(self.c, settings.s, nil)
 }
 
+func (self *Converter) AddHtml(settings *ObjectSettings, data string) {
+	c_data := C.CString(data)
+	defer C.free(unsafe.Pointer(c_data))
+	C.wkhtmltopdf_add_object(self.c, settings.s, c_data)
+}
+
 func (self *Converter) ErrorCode() int {
 	return int(C.wkhtmltopdf_http_error_code(self.c))
 }

--- a/wkhtmltopdf/pdf_c_api.go
+++ b/wkhtmltopdf/pdf_c_api.go
@@ -123,6 +123,10 @@ func (self *Converter) Convert() error {
 	return nil
 }
 
+func (self *Converter) Add(settings *ObjectSettings) {
+	C.wkhtmltopdf_add_object(self.c, settings.s, nil)
+}
+
 func (self *Converter) ErrorCode() int {
 	return int(C.wkhtmltopdf_http_error_code(self.c))
 }


### PR DESCRIPTION
The os object was never used in this example as the call to wkhtmltopdf_add_object was missing.
Also disabled javascript to make it work quicker/better and added a couple of other options (as examples) plus links to the relevant documentation for more.
Plus added the link to wkhtmltopdf download page, as this requires the library to be installed.
